### PR TITLE
[EDC-2490] Fix issue when loading edc-help from an invalid link

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'fr.techad'
-version '2.4.0-SNAPSHOT'
+version '2.4.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven-publish'

--- a/src/main/java/fr/techad/edc/client/EdcClient.java
+++ b/src/main/java/fr/techad/edc/client/EdcClient.java
@@ -49,13 +49,15 @@ public interface EdcClient {
      * <p>
      * The language code is 2 digits in lowercase ie fr, en, ...
      * If languageCode is not defined or not found, system default will be used instead
+     * Url will include the identifier of publication from where the navigation started, if present
      *
      * @param id the identifier of the documentation
      * @param languageCode the 2 letters code of the language to use
+     * @param srcPublicationId the identifier of the publication where the navigation starts from
      * @return the url
      * @throws InvalidUrlException If the url is malformed
      */
-    String getDocumentationWebHelpUrl(Long id, String languageCode) throws InvalidUrlException;
+    String getDocumentationWebHelpUrl(Long id, String languageCode, String srcPublicationId) throws InvalidUrlException;
 
     /**
      * Return the context item associated with main and sub keys and the language code.

--- a/src/main/java/fr/techad/edc/client/EdcClientSingleton.java
+++ b/src/main/java/fr/techad/edc/client/EdcClientSingleton.java
@@ -62,8 +62,8 @@ public class EdcClientSingleton implements EdcClient {
     }
 
     @Override
-    public String getDocumentationWebHelpUrl(Long id, String languageCode) throws InvalidUrlException {
-        return edcClient.getDocumentationWebHelpUrl(id, languageCode);
+    public String getDocumentationWebHelpUrl(Long id, String languageCode, String srcPublicationId) throws InvalidUrlException {
+        return edcClient.getDocumentationWebHelpUrl(id, languageCode, srcPublicationId);
     }
 
     @Override

--- a/src/main/java/fr/techad/edc/client/internal/EdcClientImpl.java
+++ b/src/main/java/fr/techad/edc/client/internal/EdcClientImpl.java
@@ -62,10 +62,10 @@ public class EdcClientImpl implements EdcClient {
     }
 
     @Override
-    public String getDocumentationWebHelpUrl(Long id, String languageCode) throws InvalidUrlException {
+    public String getDocumentationWebHelpUrl(Long id, String languageCode, String srcPublicationId) throws InvalidUrlException {
         String url;
         if (id != null)
-            url = urlUtil.getDocumentationUrl(id, languageCode);
+            url = urlUtil.getDocumentationUrl(id, languageCode, srcPublicationId);
         else
             url = urlUtil.getHomeUrl();
         return url;

--- a/src/main/java/fr/techad/edc/client/internal/util/UrlUtilImpl.java
+++ b/src/main/java/fr/techad/edc/client/internal/util/UrlUtilImpl.java
@@ -41,8 +41,9 @@ public class UrlUtilImpl implements UrlUtil {
     }
 
     @Override
-    public String getDocumentationUrl(Long id, String languageCode) throws InvalidUrlException {
+    public String getDocumentationUrl(Long id, String languageCode, String srcPublicationId) throws InvalidUrlException {
         String langCode = StringUtils.isNotBlank(languageCode) ? "/" + languageCode : "";
-        return clientConfiguration.getWebHelpUrl() + "/doc/" + id + langCode;
+        String publicationId = StringUtils.isNotBlank(srcPublicationId) ? srcPublicationId + "/" : "";
+        return clientConfiguration.getWebHelpUrl() + "/doc/" + publicationId + id + langCode;
     }
 }

--- a/src/main/java/fr/techad/edc/client/util/UrlUtil.java
+++ b/src/main/java/fr/techad/edc/client/util/UrlUtil.java
@@ -42,12 +42,14 @@ public interface UrlUtil {
 
 
     /**
-     * Build the web help documentation url for the document defined by the identifier and the language code if present
+     * Build the web help documentation url for the document defined by the identifier, the language code,
+     * and the publication identifier if present
      *
      * @param id the idenitifer of the documentation
      * @param languageCode the 2 letters code of the language (en, fr..)
+     * @param srcPublicationId the identifier of the publication from where navigation will start
      * @return the url
      * @throws InvalidUrlException If the url is malformed
      */
-    String getDocumentationUrl(Long id, String languageCode) throws InvalidUrlException;
+    String getDocumentationUrl(Long id, String languageCode, String srcPublicationId) throws InvalidUrlException;
 }

--- a/src/test/java/fr/techad/edc/client/internal/EdcClientImplTest.java
+++ b/src/test/java/fr/techad/edc/client/internal/EdcClientImplTest.java
@@ -49,13 +49,19 @@ public class EdcClientImplTest extends CommonBase {
 
     @Test
     public void shouldGetDocumentationUrl() throws InvalidUrlException {
-        String documentationWebHelpUrl = edcClient.getDocumentationWebHelpUrl(434L, "ru");
-        Assert.assertEquals("https://demo.easydoccontents.com/help/doc/434/ru", documentationWebHelpUrl);
+        String documentationWebHelpUrl = edcClient.getDocumentationWebHelpUrl(434L, "ru", "myPluginId");
+        Assert.assertEquals("https://demo.easydoccontents.com/help/doc/myPluginId/434/ru", documentationWebHelpUrl);
     }
 
     @Test
     public void shouldGetDocumentationUrlWithNullLanguage() throws InvalidUrlException {
-        String documentationWebHelpUrl = edcClient.getDocumentationWebHelpUrl(434L, null);
+        String documentationWebHelpUrl = edcClient.getDocumentationWebHelpUrl(434L, null, "myPluginId");
+        Assert.assertEquals("https://demo.easydoccontents.com/help/doc/myPluginId/434", documentationWebHelpUrl);
+    }
+
+    @Test
+    public void shouldGetDocumentationUrlWithNullPublicationId() throws InvalidUrlException {
+        String documentationWebHelpUrl = edcClient.getDocumentationWebHelpUrl(434L, null, null);
         Assert.assertEquals("https://demo.easydoccontents.com/help/doc/434", documentationWebHelpUrl);
     }
 

--- a/src/test/java/fr/techad/edc/client/internal/util/UrlUtilImplTest.java
+++ b/src/test/java/fr/techad/edc/client/internal/util/UrlUtilImplTest.java
@@ -39,21 +39,21 @@ public class UrlUtilImplTest extends CommonBase {
     @Test
     public void shouldCreateADocUrl() throws InvalidUrlException {
         UrlUtil urlUtil = createUrlBuilder();
-        String url = urlUtil.getDocumentationUrl(12L, "fr");
-        Assert.assertEquals("https://demo.easydoccontents.com/help/doc/12/fr", url);
+        String url = urlUtil.getDocumentationUrl(12L, "fr", "myPluginId");
+        Assert.assertEquals("https://demo.easydoccontents.com/help/doc/myPluginId/12/fr", url);
     }
 
     @Test
     public void shouldCreateADocUrlWithNullLanguage() throws InvalidUrlException {
         UrlUtil urlUtil = createUrlBuilder();
-        String url = urlUtil.getDocumentationUrl(12L, null);
-        Assert.assertEquals("https://demo.easydoccontents.com/help/doc/12", url);
+        String url = urlUtil.getDocumentationUrl(12L, null, "myPluginId");
+        Assert.assertEquals("https://demo.easydoccontents.com/help/doc/myPluginId/12", url);
     }
 
     @Test
     public void shouldCreateADocUrlWithNull() throws InvalidUrlException {
         UrlUtil urlUtil = createUrlBuilder();
-        String url = urlUtil.getDocumentationUrl(null, null);
+        String url = urlUtil.getDocumentationUrl(null, null, null);
         Assert.assertEquals("https://demo.easydoccontents.com/help/doc/null", url);
     }
 


### PR DESCRIPTION
- Add the publicationId in the the edc-help documentation url,
to allow edc-help to load the right context if the target link was not
valid
- set version to 2.4.1-SNAPSHOT

Epic [EDC-1796]